### PR TITLE
fix(doc): Remove references to ch_ephem.observers.get

### DIFF
--- a/ch_ephem/__init__.py
+++ b/ch_ephem/__init__.py
@@ -5,13 +5,12 @@ Instrument Observrers and General Ephemeris Routines
 
 Any ephemeris routine which needs to know the location of the
 observer on the Earth are accessible via instrument Observer
-instances obtainable through :py:meth:`ch_ephem.observers.get`:
+instances importable from :py:meth:`ch_ephem.observers`:
 
-    >>> import ch_ephem.observers
-    >>> pathfinder = ch_ephem.observers.get("pathfinder")
+    >>> from ch_ephem.observers import pathfinder
     >>> pathfinder.solar_transit(...)
 
-The `Observer` instances returned by this method are subclassed from
+The `Observer` instances provided by this module are subclassed from
 `caput.time.Observers` and can be used as normal `caput` observers.
 Location and geometry data for the instrument observers are defined
 in the data file `instruments.yaml` provided as part of `ch_ephem`.

--- a/ch_ephem/observers.py
+++ b/ch_ephem/observers.py
@@ -24,7 +24,7 @@ Observers objects found in this module subclass the standard
 `caput.time.Observer` to additionally provide rotation, roll and tangent-space
 offset for the instruments:
 
-    >>> pathfinder = ch_ephem.observers.get("pathfinder") 
+    >>> from ch_ephem.observers import pathfinder
     >>> print(pathfinder.rotation)
     1.986
     >>> print(pathfinder.roll)
@@ -173,7 +173,7 @@ def __getattr__(name: str) -> Observer:
 
     Raises
     ------
-    ValueError:
+    AttributeError:
         Data for the instrument named could not be found.
     """
 


### PR DESCRIPTION
While looking at this code in reference to https://github.com/chime-experiment/ch_util/issues/89 I realised the documentation here was referencing the non-existent function `ch_ephem.observers.get`, which existed briefly during development, before being replaced by the more intuitive way it works now where users can just import the observer they want directly from the module.