### PR TITLE
fix(instruments):Updated rotation for HCO cylinder

### DIFF
--- a/ch_ephem/instruments.yaml
+++ b/ch_ephem/instruments.yaml
@@ -105,7 +105,7 @@ hco:
   latitude: 40.8171082
   longitude: -121.4689584
   altitude: 1019.86
-  rotation: -0.8023
+  rotation: 1.145
   roll: 1.0556
   offset:
     x: 0


### PR DESCRIPTION
Rotation required to correct observed sky shifts in ringmaps in sidelobes and for `ch_cal`. 